### PR TITLE
Introduce "mouseTouch" option to avoid dragging with the mouse when "touch" is enabled

### DIFF
--- a/js/jquery.sudoSlider.js
+++ b/js/jquery.sudoSlider.js
@@ -87,7 +87,8 @@
             loadFinish: EMPTY_FUNCTION,  /* option[41]/*loadFinish*/
             touch: FALSE,  /* option[42]/*touch*/
             touchHandle: FALSE, /* option[43]/*touchHandle*/
-            destroyCallback: EMPTY_FUNCTION  /* option[44]/*destroyCallback*/
+            destroyCallback: EMPTY_FUNCTION,  /* option[44]/*destroyCallback*/
+            mouseTouch: FALSE /* option[45]/*mouseTouch*/
         };
         // Defining the base element.
         var baseSlider = this;
@@ -1218,7 +1219,9 @@
                             event.preventDefault();
                         }
                     };
-                    bindMultiple(document, dragFunction, [TOUCHSTART, TOUCHMOVE, TOUCHEND, TOUCHCANCEL, MOUSEDOWN, MOUSEMOVE, MOUSEUP]);
+                    var eventsToBind = [TOUCHSTART, TOUCHMOVE, TOUCHEND, TOUCHCANCEL];
+                    if (option[45]/*mouseTouch*/) eventsToBind = eventsToBind.concat([MOUSEDOWN, MOUSEMOVE, MOUSEUP]);
+                    bindMultiple(document, dragFunction, eventsToBind);
                 }
 
                 function allowScroll(event, isMouseEvent, prevX, prevY, x, y) {


### PR DESCRIPTION
The `touch` option works great on touch devices, but it also allows dragging slides with the mouse which I found very confusing (e.g. makes it impossible to select text inside a slide).

So I introduced a new `mouseTouch` option to enable mouse dragging explicitly. It's set to `false` by default now since that makes more sense to me.

What do you think? :)
