### PR TITLE
Improve scrolling/zooming/clicking on touch devices

### DIFF
--- a/js/jquery.sudoSlider.js
+++ b/js/jquery.sudoSlider.js
@@ -1225,8 +1225,12 @@
                 }
 
                 function allowScroll(event, isMouseEvent, prevX, prevY, x, y) {
-                    isMouseEvent = FALSE;
-                    if (isMouseEvent || isDirectionVertical(prevX, prevY, x, y) == option[7]/*vertical*/) {
+                    // If the user drags horizontally, prevent the (vertical) scroll event
+                    if (mathAbs(x) > mathAbs(y)) event.preventDefault();
+
+                    // Scrolling vertically when vertical slides are enabled should prevent
+                    // the scroll event.
+                    if (isDirectionVertical(prevX, prevY, x, y) && option[7]/*vertical*/) {
                         event.preventDefault();
                     }
                 }


### PR DESCRIPTION
I encountered problems with links inside slides that were not properly clickable on touch devices (iPad Air in my case). Double clicking did follow the link, but a single tap almost never worked.

It seems that the `allowScroll` method was the culprit, as it prevents the touch event.

There are two changes that seemed necessary to me:

``` diff
+ if (mathAbs(x) > mathAbs(y)) event.preventDefault();
```

When dragging horizontally, we want to prevent the browser's scroll event. This change also allows to start dragging horizontally and then moving downwards, as usually happens when sliding with the thumb on a phone, for example.

``` diff
- isDirectionVertical(prevX, prevY, x, y) == option[7]/*vertical*/
+ isDirectionVertical(prevX, prevY, x, y) && option[7]/*vertical*/
```

I am not sure why it read `==` here. Seems we want to prevent the browser's scroll event only when the `vertical` option on the slider is set. But a horizontal drag on horizontal slides would also fulfil the condition before -- which does not sound right to me. This is why I believe we need a `&&` here. :)

Since `isMouseEvent` was set to false anyway, I've removed it from the condition.

I am not entirely sure if my changes match your intent, since I could not find any tests. Happy to discuss if I broke anything or if it should be done differently.
